### PR TITLE
ci: reference trustify-release-tools

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ui-image-build:
-    uses: trustification/release-tools/.github/workflows/build-push-images.yaml@main
+    uses: guacsec/trustify-release-tools/.github/workflows/build-push-images.yaml@main
     with:
       registry: "ghcr.io"
       image_name: "${{ github.repository_owner }}/trustify-ui"

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -22,9 +22,9 @@ jobs:
   reconcile-issue:
     if: github.event_name == 'issues' || github.event_name == 'pull_request'
     secrets: inherit
-    uses: trustification/release-tools/.github/workflows/reconcile-issue.yaml@main
+    uses: guacsec/trustify-release-tools/.github/workflows/reconcile-issue.yaml@main
 
   reconcile-issue-comment:
     if: github.event_name == 'issue_comment'
     secrets: inherit
-    uses: trustification/release-tools/.github/workflows/reconcile-issue-comment.yaml@main
+    uses: guacsec/trustify-release-tools/.github/workflows/reconcile-issue-comment.yaml@main

--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -31,4 +31,4 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     secrets: inherit
-    uses: trustification/release-tools/.github/workflows/backport.yaml@main
+    uses: guacsec/trustify-release-tools/.github/workflows/backport.yaml@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Before submitting a PR:
 - Include relevant tests and documentation updates.
 - Link the PR to the corresponding issue (if applicable).
 
-For more information read [Trustification Versioning](https://github.com/trustification/release-tools/blob/main/VERSIONING.md).
+For more information read [Trustification Versioning](https://github.com/guacsec/trustify-release-tools/blob/main/VERSIONING.md).
 
 ### 3. Documentation Updates
 


### PR DESCRIPTION
This PR moves all old references from `trustification/release-tools` to `guacsec/trustify-release-tools`