### PR TITLE
ci: move container organization owner

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-TRUSTIFY_IMAGE=ghcr.io/trustification/trustd:latest
-TRUSTIFY_UI_IMAGE=ghcr.io/trustification/trustify-ui:latest
+TRUSTIFY_IMAGE=ghcr.io/guacsec/trustd:latest
+TRUSTIFY_UI_IMAGE=ghcr.io/guacsec/trustify-ui:latest
 
 POSTGRESQL_IMAGE=postgres:16
 

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: save trustify-ui image
         run: |
-          docker build . -t ghcr.io/trustification/trustify-ui:pr-test -f Dockerfile
-          docker save -o /tmp/trustify-ui.tar ghcr.io/trustification/trustify-ui:pr-test
+          docker build . -t ghcr.io/guacsec/trustify-ui:pr-test -f Dockerfile
+          docker save -o /tmp/trustify-ui.tar ghcr.io/guacsec/trustify-ui:pr-test
 
       - name: Upload trustify-ui image as artifact
         uses: actions/upload-artifact@v4
@@ -75,5 +75,5 @@ jobs:
     uses: ./.github/workflows/ci-e2e-template.yaml
     with:
       artifact: trustify-ui
-      ui_image: ghcr.io/trustification/trustify-ui:pr-test
-      server_image: ghcr.io/trustification/trustd:${{ needs.discover-envs-for-e2e-ci.outputs.image_tag }}
+      ui_image: ghcr.io/guacsec/trustify-ui:pr-test
+      server_image: ghcr.io/guacsec/trustd:${{ needs.discover-envs-for-e2e-ci.outputs.image_tag }}


### PR DESCRIPTION
As we moved from the old Github Organization "Trustification" to "Guacsec" we also need to migrate our references of container images