### PR TITLE
fix: hide upload btn on SearchPage/SbomTab

### DIFF
--- a/client/src/app/pages/sbom-list/sbom-toolbar.tsx
+++ b/client/src/app/pages/sbom-list/sbom-toolbar.tsx
@@ -35,12 +35,19 @@ export const SbomToolbar: React.FC<SbomToolbarProps> = ({ showFilters }) => {
   return (
     <Toolbar {...toolbarProps} aria-label="sbom-toolbar">
       <ToolbarContent>
-        {showFilters && <FilterToolbar {...filterToolbarProps} />}
-        <ToolbarItem>
-          <Button variant="primary" onClick={() => navigate(Paths.sbomUpload)}>
-            Upload SBOM
-          </Button>
-        </ToolbarItem>
+        {showFilters && (
+          <>
+            <FilterToolbar {...filterToolbarProps} />
+            <ToolbarItem>
+              <Button
+                variant="primary"
+                onClick={() => navigate(Paths.sbomUpload)}
+              >
+                Upload SBOM
+              </Button>
+            </ToolbarItem>
+          </>
+        )}
         <ToolbarItem {...paginationToolbarItemProps}>
           <SimplePagination
             idPrefix="sbom-table"


### PR DESCRIPTION
The Button for uploading SBOM should not be visible in the SEARCH PAGE but only on the SBOM List page.

The current main branch looks like the image below:

<img width="654" height="580" alt="image (3)" src="https://github.com/user-attachments/assets/cb8d8277-7421-4e24-886b-71fbc6252171" />

This PR avoids rendering that button on the SEARCH PAGE