### PR TITLE
tests (fix): wrong variable reference name

### DIFF
--- a/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
+++ b/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
@@ -57,7 +57,7 @@ Then(
 Then(
   "The vulnerabilities table is sorted by {string}",
   async ({ page }, columnName) => {
-    const toolbarTable = new ToolbarTable(page, VULNERABILITIES_TABLE_NAME);
+    const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyTableIsSortedBy(columnName);
   },
 );
@@ -65,7 +65,7 @@ Then(
 Then(
   "The vulnerabilities table total results is {int}",
   async ({ page }, totalResults) => {
-    const toolbarTable = new ToolbarTable(page, VULNERABILITIES_TABLE_NAME);
+    const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyPaginationHasTotalResults(totalResults);
   },
 );
@@ -73,7 +73,7 @@ Then(
 Then(
   "The {string} column of the vulnerability table contains {string}",
   async ({ page }, columnName, expectedValue) => {
-    const toolbarTable = new ToolbarTable(page, VULNERABILITIES_TABLE_NAME);
+    const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyColumnContainsText(columnName, expectedValue);
   },
 );


### PR DESCRIPTION
This PR makes the code to use the right variable name defined at the beginning of the file `e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts`

The variable defined is `const ADVISORY_TABLE_NAME = "Advisory table";` therefore we should use that VAR.

Note: none of the `Then` steps that this PR is touching, were invoked by any .feature file, therefore never executed. That explains why the tests were still being executed successfully.

I a separate PR we can evaluate:
- Make use of those `Then` functions into any feature file OR
- Delete those functions are they are not used anywhere.

## Summary by Sourcery

Bug Fixes:
- Replace VULNERABILITIES_TABLE_NAME with the correct VULN_TABLE_NAME in vulnerability table step implementations