### PR TITLE
tests: extract sbom-search assertions to its own feature

### DIFF
--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -28,7 +28,7 @@ Feature: SBOM Explorer - View SBOM details
         Examples:
             | sbomName    |
             | quarkus-bom |
-    
+
     Scenario Outline: Downloading SBOM file
         Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
@@ -38,7 +38,7 @@ Feature: SBOM Explorer - View SBOM details
         Examples:
             | sbomName    | expectedSbomFilename | expectedLicenseFilename     |
             | quarkus-bom | quarkus-bom.json     | quarkus-bom_licenses.tar.gz |
-    
+
     Scenario Outline: View list of SBOM Packages
         Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
@@ -125,14 +125,6 @@ Feature: SBOM Explorer - View SBOM details
         Examples:
         | sbomName    |
         | quarkus-bom |
-
-    Scenario Outline: Add Labels to SBOM from SBOM List Page
-        Given An ingested SBOM "<sbomName>" is available
-        When User Adds Labels "<Labels>" to "<sbomName>" SBOM from List Page
-        Then The Label list "<Labels>" added to the SBOM "<sbomName>" on List Page
-        Examples:
-        | sbomName    |     Labels    |
-        | quarkus-bom | RANDOM_LABELS |
 
     Scenario Outline: Add Labels to SBOM from SBOM Explorer Page
         Given An ingested SBOM "<sbomName>" is available

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -64,7 +64,6 @@ Feature: SBOM Explorer - View SBOM details
 
     Scenario Outline: View SBOM Vulnerabilities
         Given An ingested SBOM "<sbomName>" is available
-        Given An ingested SBOM "<sbomName>" containing Vulnerabilities
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         When User Clicks on Vulnerabilities Tab Action
@@ -83,7 +82,6 @@ Feature: SBOM Explorer - View SBOM details
     @slow
     Scenario Outline: Pagination of SBOM Vulnerabilities table
         Given An ingested SBOM "<sbomName>" is available
-        Given An ingested SBOM "<sbomName>" containing Vulnerabilities
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Pagination of Vulnerabilities list works
@@ -103,7 +101,6 @@ Feature: SBOM Explorer - View SBOM details
 
     Scenario Outline: Check Column Headers of SBOM Explorer Vulnerabilities table
         Given An ingested SBOM "<sbomName>" is available
-        Given An ingested SBOM "<sbomName>" containing Vulnerabilities
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then List of Vulnerabilities has column "Id"
@@ -119,7 +116,6 @@ Feature: SBOM Explorer - View SBOM details
     @slow
     Scenario Outline: Sorting SBOM Vulnerabilities
         Given An ingested SBOM "<sbomName>" is available
-        Given An ingested SBOM "<sbomName>" containing Vulnerabilities
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Table column "Description" is not sortable

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -9,7 +9,6 @@ export const { Given, When, Then } = createBdd(test);
 
 const PACKAGE_TABLE_NAME = "Package table";
 const VULN_TABLE_NAME = "Vulnerability table";
-const SBOM_TABLE_NAME = "sbom-table";
 
 Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
   const sbomListPage = await SbomListPage.build(page);
@@ -184,43 +183,6 @@ Then(
     const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     const vulnTableTopPagination = `xpath=//div[@id="vulnerability-table-pagination-top"]`;
     await toolbarTable.verifySorting(vulnTableTopPagination, headers);
-  },
-);
-
-When(
-  "User Adds Labels {string} to {string} SBOM from List Page",
-  async ({ page }, labelList, sbomName) => {
-    const toolbarTable = new ToolbarTable(page, SBOM_TABLE_NAME);
-    await toolbarTable.editLabelsListPage(sbomName);
-    const detailsPage = new DetailsPage(page);
-
-    // Generate random labels if placeholder is used
-    const labelsToAdd =
-      labelList === "RANDOM_LABELS" ? detailsPage.generateLabels() : labelList;
-    await detailsPage.addLabels(labelsToAdd);
-
-    // Store generated labels for verification
-    // biome-ignore lint/suspicious/noExplicitAny: allowed
-    (page as any).testContext = {
-      // biome-ignore lint/suspicious/noExplicitAny: allowed
-      ...(page as any).testContext,
-      generatedLabels: labelsToAdd,
-    };
-  },
-);
-
-Then(
-  "The Label list {string} added to the SBOM {string} on List Page",
-  async ({ page }, labelList, sbomName) => {
-    const detailsPage = new DetailsPage(page);
-
-    // Use stored generated labels if placeholder was used
-    const labelsToVerify =
-      labelList === "RANDOM_LABELS"
-        ? // biome-ignore lint/suspicious/noExplicitAny: allowed
-          (page as any).testContext?.generatedLabels || labelList
-        : labelList;
-    await detailsPage.verifyLabels(labelsToVerify, sbomName);
   },
 );
 

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -87,18 +87,6 @@ Then(
   },
 );
 
-Given(
-  "An ingested SBOM {string} containing Vulnerabilities",
-  async ({ page }, sbomName) => {
-    const element = page.locator(
-      `xpath=(//tr[contains(.,'${sbomName}')]/td[@data-label='Vulnerabilities']/div)[1]`,
-    );
-    await expect(element, "SBOM have no vulnerabilities").toHaveText(
-      /^(?!0$).+/,
-    );
-  },
-);
-
 When("User Clicks on Vulnerabilities Tab Action", async ({ page }) => {
   await page.getByLabel("Tab action").click();
 });

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.feature
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.feature
@@ -9,3 +9,11 @@ Feature: SBOM Search Page
         Examples:
             | sbomName    |
             | quarkus-bom |
+
+     Scenario Outline: Add Labels to SBOM from SBOM List Page
+        Given An ingested SBOM "<sbomName>" is available
+        When User Adds Labels "<Labels>" to "<sbomName>" SBOM from List Page
+        Then The Label list "<Labels>" added to the SBOM "<sbomName>" on List Page
+        Examples:
+        | sbomName    |     Labels    |
+        | quarkus-bom | RANDOM_LABELS |

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.feature
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.feature
@@ -1,0 +1,11 @@
+Feature: SBOM Search Page
+    Background: Authentication
+        Given User is authenticated
+
+    Scenario Outline: Verify Vulnerabilities
+        Given An ingested SBOM "<sbomName>" is available
+        Given An ingested SBOM "<sbomName>" containing Vulnerabilities
+
+        Examples:
+            | sbomName    |
+            | quarkus-bom |

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
@@ -1,0 +1,29 @@
+import { createBdd } from "playwright-bdd";
+import { expect } from "playwright/test";
+import { test } from "../../fixtures";
+import { SbomListPage } from "../../pages/sbom-list/SbomListPage";
+
+export const { Given, When, Then } = createBdd(test);
+
+Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
+  const sbomListPage = await SbomListPage.build(page);
+
+  const toolbar = await sbomListPage.getToolbar();
+  const table = await sbomListPage.getTable();
+
+  await toolbar.applyTextFilter("Filter text", sbomName);
+  await table.waitUntilDataIsLoaded();
+  await table.verifyColumnContainsText("Name", sbomName);
+});
+
+Given(
+  "An ingested SBOM {string} containing Vulnerabilities",
+  async ({ page }, sbomName) => {
+    const element = page.locator(
+      `xpath=(//tr[contains(.,'${sbomName}')]/td[@data-label='Vulnerabilities']/div)[1]`,
+    );
+    await expect(element, "SBOM have no vulnerabilities").toHaveText(
+      /^(?!0$).+/,
+    );
+  },
+);


### PR DESCRIPTION
### Summary:
Move tests that belongs to the SBOM List Search Page to its own directory

Reasoning:

`e2e/tests/ui/features/@sbom-explorer` should contain tests or assertions that are only related to the SBOM Details Page.
Currently, in the main branch, there is a step `Given An ingested SBOM "<sbomName>" containing Vulnerabilities` that executes tests to SBOM List page. 

- This PR extracts tests from the SBOM Details Page to the SBOM Search Page.
- The `@sbom-explorer` tests can/should assume everything is fine until the moment we reach the SBOM Details Page, and leave intermediate tests to other tests.

## Summary by Sourcery

Extract vulnerability assertions from SBOM Explorer tests into a new SBOM Search feature, adding focused step definitions and feature file while removing redundant checks from the SBOM Explorer details tests.

New Features:
- Add SBOM Search Page feature with scenarios to verify SBOM availability and vulnerability presence in the list view.

Enhancements:
- Extract vulnerability-related steps from SBOM Explorer details tests into a dedicated SBOM Search feature.

Tests:
- Add step definitions and feature file for SBOM Search Page including list filtering and vulnerability count checks.