### PR TITLE
tests (fix): enhance table wait assertions to avoid flaky tests

### DIFF
--- a/e2e/tests/ui/pages/Table.ts
+++ b/e2e/tests/ui/pages/Table.ts
@@ -23,14 +23,19 @@ export class Table {
     return result;
   }
 
+  /**
+   * Waits until the table is not in "Loading" state.
+   */
   async waitUntilDataIsLoaded() {
+    // If table already has data, we need to wait to be sure we are not asserting the previous page
+    await this._page.waitForTimeout(500);
+
     const rows = this._table.locator(
       'xpath=//tbody[not(@aria-label="Table loading")]',
     );
     await expect(rows.first()).toBeVisible();
 
-    const rowsCount = await rows.count();
-    expect(rowsCount).toBeGreaterThanOrEqual(1);
+    await expect.poll(() => rows.count()).toBeGreaterThanOrEqual(1);
   }
 
   async clickSortBy(columnName: string) {
@@ -80,13 +85,15 @@ export class Table {
     const rows = this._table.locator(`td[data-label="${columnName}"]`);
 
     if (expectedRows.equal) {
-      expect(await rows.count()).toBe(expectedRows.equal);
+      await expect.poll(() => rows.count()).toBe(expectedRows.equal);
     }
     if (expectedRows.greaterThan) {
-      expect(await rows.count()).toBeGreaterThan(expectedRows.greaterThan);
+      await expect
+        .poll(() => rows.count())
+        .toBeGreaterThan(expectedRows.greaterThan);
     }
     if (expectedRows.lessThan) {
-      expect(await rows.count()).toBeLessThan(expectedRows.lessThan);
+      await expect.poll(() => rows.count()).toBeLessThan(expectedRows.lessThan);
     }
   }
 }


### PR DESCRIPTION
Code enhancements to wait helpers.
- Introduction of "poll" to recurrently verify data until the expected assertion passes.
- Enhance `waitUntilDataIsLoaded` => adding a reasonable time to wait for the table start transitioning from "loading" to "loaded" before the assertions are done.