### PR TITLE
fix: window.history.replaceState does not work on react-router-dom v7

### DIFF
--- a/client/src/app/components/OidcProvider.tsx
+++ b/client/src/app/components/OidcProvider.tsx
@@ -5,6 +5,8 @@ import { AuthProvider, useAuth } from "react-oidc-context";
 import { initInterceptors } from "@app/axios-config";
 import ENV from "@app/env";
 import { oidcClientSettings } from "@app/oidc";
+import { AppRoutes } from "@app/Routes";
+
 import {
   Bullseye,
   EmptyState,
@@ -29,7 +31,7 @@ export const OidcProvider: React.FC<IOidcProviderProps> = ({ children }) => {
       onSigninCallback={() => {
         const params = new URLSearchParams(window.location.search);
         const relativePath = params.get("state")?.split(";")?.[1];
-        window.history.replaceState({}, document.title, relativePath ?? "/");
+        AppRoutes.navigate(relativePath ?? "/");
       }}
     >
       <AuthEnabledOidcProvider>{children}</AuthEnabledOidcProvider>

--- a/client/src/app/components/OidcProvider.tsx
+++ b/client/src/app/components/OidcProvider.tsx
@@ -31,7 +31,7 @@ export const OidcProvider: React.FC<IOidcProviderProps> = ({ children }) => {
       onSigninCallback={() => {
         const params = new URLSearchParams(window.location.search);
         const relativePath = params.get("state")?.split(";")?.[1];
-        AppRoutes.navigate(relativePath ?? "/");
+        AppRoutes.navigate(relativePath ?? "/", { replace: true });
       }}
     >
       <AuthEnabledOidcProvider>{children}</AuthEnabledOidcProvider>


### PR DESCRIPTION
Fixes: https://github.com/guacsec/trustify-ui/issues/738

react-router-dom seems not to catch direct calls to window.history.replaceState but it does to `AppRoutes.navigate`

## Summary by Sourcery

Bug Fixes:
- Replace window.history.replaceState calls with AppRoutes.navigate in the OIDC provider to ensure proper routing under react-router-dom v7