### PR TITLE
feat: SBOM Details (Vulnerability) parity with Scan SBOM Report

### DIFF
--- a/client/src/app/pages/sbom-scan/scan-utils.ts
+++ b/client/src/app/pages/sbom-scan/scan-utils.ts
@@ -1,11 +1,13 @@
-import type { AdvisoryHead } from "@app/client";
+import type { Labels } from "@app/client";
 import { formatDate } from "@app/utils/utils";
 import type { VulnerabilityOfSbomFromAnalysis } from "./hooks/useVulnerabilitiesOfSbom";
 
 const IMPORTER_NAME_LABEL_KEY = "importer";
 const UNKNOWN_IMPORTER_NAME = "Unknown";
 
-export const extractImporterNameFromAdvisory = (advisory: AdvisoryHead) => {
+export const extractImporterNameFromAdvisory = (advisory: {
+  labels: Labels;
+}) => {
   return advisory.labels[IMPORTER_NAME_LABEL_KEY] ?? UNKNOWN_IMPORTER_NAME;
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Align the SBOM vulnerabilities details page with the scan report by refactoring the data model, table layout, and adding filtering capabilities.

New Features:
- Add search filter for Vulnerability ID and multiselect filters for Importer and Status in the vulnerabilities table
- Introduce a Status column with VulnerabilityStatusLabel and rename/reorder table columns to match the scan report view

Enhancements:
- Refactor useVulnerabilitiesOfSbom hook to aggregate advisories and packages into maps and rename vulnerabilityStatus to status
- Replace manual SBOM summary and donut chart UI with unified vulnerabilities data from the hook
- Update extractImporterNameFromAdvisory to accept a generic labels type