### PR TITLE
task: package.json update to run BDD scripts alone

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -64,6 +64,8 @@ There are some pre-configured commands you can use:
 | npm run test          | Execute UI and API tests                                                          |
 | npm run test:ui       | Execute UI tests                                                                  |
 | npm run test:ui:trace | Execute UI tests and take screenshots                                             |
+| npm run test:bdd      | Execute UI tests under feature files in BDD format                                |
+| npm run test:bdd:trace| Execute UI tests under feature files in BDD format and take screenshots           |
 | npm run test:ui:host  | Opens the Playwright UI in the browser of your OS                                 |
 | npm run test:api      | Execute API test                                                                  |
 | npm run format:fix    | Reformat source code according using `biome` (use before committing code changes) |

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,8 @@
     "test:ui": "npx bddgen && npx playwright test --project='chromium' --project='bdd'",
     "test:ui:trace": "npx bddgen && npx playwright test --project='chromium' --project='bdd' --trace on",
     "test:ui:host": "npx bddgen && npx playwright test --ui-host 127.0.0.1",
+    "test:bdd": "npx bddgen && npx playwright test --project='bdd'",
+    "test:bdd:trace": "npx bddgen && npx playwright test --project='bdd' --trace on",
     "check": "biome check --error-on-warnings .",
     "check:write": "biome check --write .",
     "format": "biome format .",


### PR DESCRIPTION
Existing scripts executes all the UI tests under `e2e/tests` directory, where as the `test:bdd` targets only the BDD test scenarios under feature files (`bddTestDir`).