### PR TITLE
fix: dashboard - handle deleted sboms

### DIFF
--- a/client/src/app/pages/home/watched-sboms-context.tsx
+++ b/client/src/app/pages/home/watched-sboms-context.tsx
@@ -14,7 +14,7 @@ interface IWatchedSbomsContext {
   isFetching: boolean;
   fetchError: AxiosError | null;
 
-  patch: (key: string, value: string) => void;
+  patch: (key: string, value: string | null) => void;
 }
 
 const contextDefaultValue = {} as IWatchedSbomsContext;
@@ -46,10 +46,13 @@ export const WatchedSbomsProvider: React.FunctionComponent<
     onUpdateError,
   );
 
-  const patch = (key: string, value: string) => {
-    const newSboms = { ...sboms, [key]: value };
-    updateSboms(newSboms as WatchedSboms);
-  };
+  const patch = React.useCallback(
+    (key: string, value: string | null) => {
+      const newSboms = { ...sboms, [key]: value };
+      updateSboms(newSboms as WatchedSboms);
+    },
+    [sboms, updateSboms],
+  );
 
   return (
     <WatchedSbomsContext.Provider

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -26,7 +26,6 @@ import {
 import { useUpload } from "@app/hooks/useUpload";
 
 import { uploadSbom } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import {
   labelRequestParamsQuery,
   requestParamsQuery,
@@ -89,7 +88,7 @@ export const useFetchSBOMs = (
 
 export const useFetchSBOMById = (
   id?: string,
-  refetchInterval? : number | false,
+  refetchInterval?: number | false,
   retry?: boolean | number,
 ) => {
   const { data, isLoading, error } = useQuery({
@@ -125,7 +124,7 @@ export const useDeleteSbomMutation = (
       onSuccess(response, id);
       await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
       await queryClient.invalidateQueries({ queryKey: [DashboardQueryKey] });
-      
+
       // Required as SBOMs in other pages might need to to be removed
       // https://github.com/TanStack/query/discussions/3169#discussioncomment-14347395
       queryClient.removeQueries({ queryKey: [SBOMsQueryKey, id] });

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -123,8 +123,6 @@ export const useDeleteSbomMutation = (
       onSuccess(response, id);
       await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
 
-      // Required as SBOMs in other pages might need to to be removed
-      // https://github.com/TanStack/query/discussions/3169#discussioncomment-14347395
       queryClient.removeQueries({ queryKey: [SBOMsQueryKey, id] });
     },
     onError: async (err: AxiosError) => {

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -30,7 +30,6 @@ import {
   labelRequestParamsQuery,
   requestParamsQuery,
 } from "../hooks/table-controls";
-import { DashboardQueryKey } from "./dashboard";
 
 export const SBOMsQueryKey = "sboms";
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -123,7 +123,6 @@ export const useDeleteSbomMutation = (
     onSuccess: async (response, id) => {
       onSuccess(response, id);
       await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
-      await queryClient.invalidateQueries({ queryKey: [DashboardQueryKey] });
 
       // Required as SBOMs in other pages might need to to be removed
       // https://github.com/TanStack/query/discussions/3169#discussioncomment-14347395
@@ -132,7 +131,6 @@ export const useDeleteSbomMutation = (
     onError: async (err: AxiosError) => {
       onError(err);
       await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
-      await queryClient.invalidateQueries({ queryKey: [DashboardQueryKey] });
     },
   });
 };


### PR DESCRIPTION
fixes: https://github.com/guacsec/trustify-ui/issues/750

If the SBOM fetch contains 404 then the dashboard will assume the SBOM has been deleting and update the user preferences accordingly.

## Summary by Sourcery

Handle deleted SBOMs in the dashboard by automatically clearing user preferences on 404 fetch errors and updating query caches accordingly

Bug Fixes:
- Clear watched SBOM preference when fetching a SBOM returns a 404 error

Enhancements:
- Extend useFetchSBOMById hook to accept refetchInterval and retry options
- Include deletion and ongoing mutation states in the loading indicator
- Invalidate dashboard queries and remove individual SBOM cache after deletion
- Allow null values in watched SBOM context patch and memoize the patch function with useCallback