### PR TITLE
chore: change the SBOM package license filter operator (TC-2981)

### DIFF
--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -82,7 +82,7 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
         title: "License",
         placeholderText: "Filter results by license",
         type: FilterType.multiselect,
-        operator: "~",
+        operator: "=",
         logicOperator: "OR",
         selectOptions: licenseIds.map((license) => ({
           value: license.license_id,


### PR DESCRIPTION
**_Draft as long as the dependency PR for the backend https://github.com/guacsec/trustify/pull/2011 won't be merged._**

Currently the SBOM Packages tab in the SBOM details page has a license filter that works letting the user only to select the "base" licenses (e.g. "GPLv2+") but not any license coming from SPDX license expressions available in the SBOM itself.
With the recent enhancements done for [TC-1903](https://issues.redhat.com/browse/TC-1903), the license filtering has been improved in order to successfully manage also SPDX license expressions and so the SBOM Packages license filter must be consistently enhanced as well to work with `equal` operator to have the expected results.

Relates to https://issues.redhat.com/browse/TC-2981

## Summary by Sourcery

Enhancements:
- Change license filter operator from '~' to '=' to correctly filter SPDX license expressions